### PR TITLE
test_volume_list_admin_context: add tests

### DIFF
--- a/rackspace_cinder_extensions/tests/unit/policy.json
+++ b/rackspace_cinder_extensions/tests/unit/policy.json
@@ -2,6 +2,8 @@
     "context_is_admin": [["role:admin"]],
     "admin_api": [["is_admin:True"]],
 
-    "volume_extension:snapshot_progress": [["rule:admin_api"]]
-}
+    "default": "",
 
+    "volume_extension:snapshot_progress": [["rule:admin_api"]],
+    "volume_extension:volume_list_admin_context": [["role:fake"]]
+}

--- a/rackspace_cinder_extensions/tests/unit/test_volume_list_admin_context.py
+++ b/rackspace_cinder_extensions/tests/unit/test_volume_list_admin_context.py
@@ -1,0 +1,50 @@
+import webob
+import mock
+
+from cinder import context
+from cinder.tests.unit.api import fakes
+
+from rackspace_cinder_extensions import test
+
+
+class VolumeListAdminContextTestCase(test.TestCase):
+
+    _authorized_roles = ['fake']
+    _unauthorized_roles = []
+
+    def _get_response(self, roles):
+        ctx = context.RequestContext('admin', 'fake', False,
+                                     roles=roles)
+
+        req = webob.Request.blank('/v2/fake/volumes/detail?host=fake&all_tenants=1')
+        req.method = 'GET'
+
+        res = req.get_response(fakes.wsgi_app(fake_auth_context=ctx))
+
+        return res
+
+    @mock.patch('cinder.volume.api.API.get_all')
+    def test_authorized_filter_context(self, get_all):
+        roles = self._authorized_roles
+        res = self._get_response(roles)
+
+        self.assertEqual(200, res.status_int)
+
+        get_all.assert_called_once_with(mock.ANY, mock.ANY, mock.ANY,
+                                        filters={'host': 'fake', 'all_tenants': 1},
+                                        offset=mock.ANY,
+                                        sort_dirs=mock.ANY, sort_keys=mock.ANY,
+                                        viewable_admin_meta=mock.ANY)
+
+    @mock.patch('cinder.volume.api.API.get_all')
+    def test_unauthorized_filter_context(self, get_all):
+        roles = self._unauthorized_roles
+        res = self._get_response(roles)
+
+        self.assertEqual(200, res.status_int)
+
+        get_all.assert_called_once_with(mock.ANY, mock.ANY, mock.ANY,
+                                        filters={},
+                                        offset=mock.ANY,
+                                        sort_dirs=mock.ANY, sort_keys=mock.ANY,
+                                        viewable_admin_meta=mock.ANY)


### PR DESCRIPTION
I thought about patching `RequestContext.elevated` instead, but that isn't reliably not-called.

**requires**: #21
**requires**: #20