### PR TITLE
rax_extensions: remove

### DIFF
--- a/rackspace_cinder_extensions/__init__.py
+++ b/rackspace_cinder_extensions/__init__.py
@@ -12,52 +12,27 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-try:
-    from oslo_config import cfg
-except ImportError:
-    from oslo.config import cfg
-try:
-    from oslo_log import log as logging
-except ImportError:
-    from cinder.openstack.common import log as logging
+from oslo_config import cfg
+from oslo_log import log as logging
 
 from cinder.api import extensions
-import os
+
+# import registers global options
+from rackspace_cinder_extensions.common import config
+
 
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
 
+
+def standard_extensions(ext_mgr):
+    extensions.load_standard_extensions(ext_mgr, LOG, __path__, __package__)
+
+
+def select_extensions(ext_mgr):
+    extensions.load_standard_extensions(ext_mgr, LOG, __path__, __package__,
+                                        CONF.rsapi_volume_ext_list)
+
+
 def rax_extensions(ext_mgr):
-    """ Load any extensions where this package resides """
-
-    # Walk through all the modules in our directory...
-    our_dir = __path__[0]
-    for dirpath, dirnames, filenames in os.walk(our_dir):
-        # Compute the relative package name from the dirpath
-        relpath = os.path.relpath(dirpath, our_dir)
-        if relpath == '.':
-            relpkg = ''
-        else:
-            relpkg = '.%s' % '.'.join(relpath.split(os.sep))
-
-        # Now, consider each file in turn, only considering .py files
-        for fname in filenames:
-            root, ext = os.path.splitext(fname)
-            # Skip test directory
-            if dirpath.endswith('test'):
-                continue
-            # Skip __init__ and anything that's not .py
-            if ext != '.py' or root == '__init__':
-                continue
-
-            # Try loading it
-            classname = "%s%s" % (root[0].upper(), root[1:])
-            classpath = ("%s%s.%s.%s" %
-                         (__package__, relpkg, root, classname))
-
-            try:
-                ext_mgr.load_extension(classpath)
-            except Exception as exc:
-                LOG.warn(_('Failed to load extension %(classpath)s: '
-                              '%(exc)s'),
-                            {'classpath': classpath, 'exc': exc})
+    standard_extensions(ext_mgr)

--- a/rackspace_cinder_extensions/common/config.py
+++ b/rackspace_cinder_extensions/common/config.py
@@ -1,0 +1,14 @@
+from oslo_config import cfg
+
+
+CONF = cfg.CONF
+
+global_opts = [
+    cfg.StrOpt('rsapi_volume_ext_list',
+               default=[],
+               help='Specify list of extensions to load when using osapi_'
+                     'volume_extension option with rackspace_cinder_extensions.'
+                     'select_extensions'),
+]
+
+CONF.register_opts(global_opts)


### PR DESCRIPTION
This replaces the `rax_extensions` loader with the `cinder.api.extensions` loader.

This also adds a new configuration option, `rsapi_volume_ext_list`, which has the same usage as `osapi_volume_ext_list`.