### PR TITLE
setup: use pbr

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,23 @@
+[metadata]
+name = rackspace_cinder_extensions
+summary = Rackspace Cinder Extensions
+description-file =
+    README.md
+author = Cory Stone
+author-email = cory.stone@gmail.com
+maintainer = Cory Wright
+maintainer-email = corywright@gmail.com
+home-page = 'https://github.com/rackerlabs/rackspace_cinder_extensions'
+classifier =
+    Environment :: OpenStack
+    Intended Audience :: Information Technology
+    Intended Audience :: System Administrators
+    License :: OSI Approved :: Apache Software License
+    Operating System :: POSIX :: Linux
+    Programming Language :: Python
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
+
+[files]
+packages =
+    rackspace_cinder_extensions

--- a/setup.py
+++ b/setup.py
@@ -14,34 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from setuptools import setup, find_packages
-
-version = '0.7'
+from setuptools import setup
 
 setup(
-    name='rackspace_cinder_extensions',
-    version=version,
-    author='Cory Stone',
-    author_email='cory.stone@gmail.com',
-    maintainer='Cory Wright',
-    maintainer_email='corywright@gmail.com',
-    description='Rackspace Cinder Extensions',
-    license='Apache License, Version 2.0',
-    packages=find_packages(exclude=['test']),
-    url='https://github.com/rackerlabs/rackspace_cinder_extensions',
-    install_requires=['python-lunrclient>=1.1.0'],
-    data_files=[
-        ('share/doc/python-rackspace-cinder-extensions',
-         ['CHANGES', 'CONTRIBUTORS', 'LICENSE', 'README.md']),
-    ],
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        'Environment :: OpenStack',
-        "Intended Audience :: Developers",
-        "Intended Audience :: Information Technology",
-        'Intended Audience :: System Administrators',
-        "License :: OSI Approved :: Apache Software License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python",
-    ]
+    setup_requires=['pbr>=1.8'],
+    pbr=True
 )


### PR DESCRIPTION
This migrates `setup` to pbr.

With no additional work, this will break versioning. There are two options, I think:

 * [rename](https://gist.github.com/buhman/c750e8fa667e43e89aa24f590d30821e) existing tags
 * tag this merge commit with `0.8.0`

Or both, but not neither.