### PR TITLE
CBS-539 Fixing get-volume extension failure

### DIFF
--- a/rackspace_cinder_extensions/api/contrib/rax_admin.py
+++ b/rackspace_cinder_extensions/api/contrib/rax_admin.py
@@ -200,7 +200,7 @@ class RaxAdminController(wsgi.Controller):
             volume.update(dict(lunr_exports=[lunr_exports]))
         volume.update(dict(lunr_nodes=lunr_nodes))
         # Get volume data specific to the storage node resource (direct from storage node)
-        url = 'http://' + lunr_nodes['hostname'] + ':8080/' + CONF.lunr_api_version + '/admin'
+        url = 'http://%s:%s' % (lunr_nodes['hostname'], str(lunr_nodes['port']))
         storage_client = lunrclient.client.StorageClient(url)
         storage_volumes = lunr_except_handler(lambda: storage_client.volumes.get(volume_id))
         storage_exports = lunr_except_handler(lambda: storage_client.exports.get(volume_id))


### PR DESCRIPTION
CBS-539 Fixing get-volume extension failure. Added correct url to hit the storage node.